### PR TITLE
Refactor to use multiple years from scraper config

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -17,199 +17,211 @@ namespace prospect_scraper_mddb_2022
     {
         static void Main(string[] args)
         {
-            int bigBoards = 0;
-            int mockDrafts = 0;
-            int teamMockDrafts = 0;
-            int schools = 0;
-            int states = 0;
-
-
-            var scraperConfig = new Configuration();
-            scraperConfig = Configuration.LoadFromFile("scraper.conf");
+            var scraperConfig = Configuration.LoadFromFile("scraper.conf");
             var pageSection = scraperConfig["Pages"];
             var generalSection = scraperConfig["General"];
 
             AnsiConsole.Status()
-            .Start("Thinking...", ctx => 
+            .Start("Thinking...", ctx =>
             {
                 ctx.Spinner(Spinner.Known.Star);
-                var webGet = new HtmlWeb();
-                webGet.UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0";
-                string scrapeYear = generalSection["YearToScrape"].StringValue;
-                string urlToScrape = scrapeYear + "Url";
-                var document = webGet.Load(pageSection[urlToScrape].StringValue);
-                // This is still messy from debugging the different values.  It should be optimized.
-                var dn = document.DocumentNode;
-                // https://html-agility-pack.net/select-nodes
-                // 2022 NFL Draft was compiled using 1 Big Board(s), 14 1st RoundMock Draft(s), and 0 Team BasedMock Draft(s). 
-                // /html/body/div.container/div.consensus-mock-container/ul/li
-                
-                var bigBoard = dn.SelectNodes("//div[contains(@class, 'consensus-mock-container')]/ul/li");
-                var draftInfo = dn.SelectNodes("//div[contains(@class, 'list-title')]");
-                var lastUpdated = draftInfo[0].ChildNodes[2].InnerText.Replace("Last Updated: ", "").Trim();
-                var boardCountContainer = draftInfo[0].ChildNodes[1];
-                //var bigboardsUsed = dn.SelectNodes("/html[1]/body[1]/div[1]/div[2]/div[2]/p[1]/span[1]");
-                //var mockDraftsUsed = dn.SelectNodes("/html[1]/body[1]/div[1]/div[2]/div[2]/p[1]/span[2]");
-                //var teamBasedMockDraftsUsed = dn.SelectNodes("/html[1]/body[1]/div[1]/div[2]/div[2]/p[1]/span[3]");
-                //bool bigBoardParsed = int.TryParse(bigboardsUsed[0].InnerText, out bigBoards);
-                //bool mockDraftParsed = int.TryParse(mockDraftsUsed[0].InnerText, out mockDrafts);
-                //bool teamMockDraftParsed = int.TryParse(teamBasedMockDraftsUsed[0].InnerText, out teamMockDrafts);
-                bool bigBoardParsed = int.TryParse(boardCountContainer.ChildNodes[1].InnerText, out bigBoards);
-                bool mockDraftParsed = int.TryParse(boardCountContainer.ChildNodes[4].InnerText, out mockDrafts);
-                bool teamMockDraftParsed = int.TryParse(boardCountContainer.ChildNodes[7].InnerText, out teamMockDrafts);
-                
-                Console.WriteLine("Big Board count: " + bigBoards);
-                Console.WriteLine("Mock Draft count: " + mockDrafts);
-                Console.WriteLine("Team Mock count: " + teamMockDrafts);
-                
-                Console.WriteLine("Prospect count: " + bigBoard.Count);
-                
-                // Get today's date in the format of yyyy-mm-dd
-                string today = DateTime.Now.ToString("yyyy-MM-dd");
-
-                // Create a ConsensusBigBoardInfo object from the parsed values.
-                var bigBoardInfo = new ConsensusBigBoardInfo(today, bigBoards, mockDrafts, teamMockDrafts, bigBoard.Count, lastUpdated);
-                List<ConsensusBigBoardInfo> infos = new List<ConsensusBigBoardInfo>();
-                infos.Add(bigBoardInfo);
-
-
-                // use CsvWriter to write bigBoardInfo to csv
-               
-                //This is the file name we are going to write.
-                var bigBoardInfoFileName = $"ranks{Path.DirectorySeparatorChar}{scrapeYear}{Path.DirectorySeparatorChar}{scrapeYear}BoardInfo.csv";
-
-                Console.WriteLine("Creating Draft Info csv...");
-                
-                var consensusConfig = new CsvConfiguration(CultureInfo.CurrentCulture);
-                consensusConfig.HasHeaderRecord =  false;
-                //Write projects to csv with date.
-                using (var stream = File.Open(bigBoardInfoFileName, FileMode.Append))
-                using (var writer = new StreamWriter(stream))
-                using (var csv = new CsvWriter(writer, consensusConfig))
+                var webGet = new HtmlWeb
                 {
-                    csv.WriteRecords(infos);
-                }
-            
-                ctx.SpinnerStyle(Style.Parse("green"));
+                    UserAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:91.0) Gecko/20100101 Firefox/91.0"
+                };
 
-                AnsiConsole.MarkupLine("Doing some prospect work...");
-                var prospects = findProspects(bigBoard, today);
-
-                
-                // Update the status and spinner
-                ctx.Status("Writing draft prospect CSV");
-                var playerInfoFileName = $"ranks{Path.DirectorySeparatorChar}{scrapeYear}{Path.DirectorySeparatorChar}players{Path.DirectorySeparatorChar}{today}-ranks.csv";
-                var collectedRanksFileName = $"ranks{Path.DirectorySeparatorChar}{scrapeYear}{Path.DirectorySeparatorChar}{scrapeYear}ranks.csv";
-
-                //Write projects to csv with date.
-                using (var writer = new StreamWriter(playerInfoFileName))
-                using (var csv = new CsvWriter(writer, CultureInfo.CurrentCulture))
+                var scrapeYears = generalSection["YearsToScrape"].StringValueArray;
+                for (var i = 0; i < scrapeYears.Length; i++)
                 {
-                    csv.WriteRecords(prospects);
-                }
-                
-                ctx.Status("Writing to collected ranks CSV");
-                var collectedRanksConfig = new CsvConfiguration(CultureInfo.CurrentCulture);
-                collectedRanksConfig.HasHeaderRecord =  false;
-                //Write projects to csv with date.
-                using (var stream = File.Open(collectedRanksFileName, FileMode.Append))
-                using (var writer = new StreamWriter(stream))
-                using (var csv = new CsvWriter(writer, collectedRanksConfig))
-                {
-                    csv.WriteRecords(prospects);
+                    var scrapeYear = scrapeYears[i];
+                    var urlToScrape = GetUrlToScrape(scrapeYear, pageSection);
+                    ScrapeYear(ctx, webGet, scrapeYear, urlToScrape);
                 }
 
-                // OK, I'm going to use LINQ to sort the top schools by points, then by number of prospects.
-                // The output I want here is: Rank, School, Conference, Points, Number of Prospects
-                ctx.Status($"Putting together top schools....");
-
-                var topSchools = prospects.GroupBy(x => x.School)
-                    .Select(x => new {
-                        School = x.Key,
-                        Conference = x.First().Conference,
-                        ProjectedPoints = x.Sum(y => y.ProjectedPoints),
-                        NumberOfProspects = x.Count()
-                    })
-                    .OrderByDescending(x => x.ProjectedPoints)
-                    .ThenByDescending(x => x.NumberOfProspects)
-                    .ToList();
-                schools = topSchools.Count();
-
-                // Chatty output to console.  It's messy but informative.
-                Console.WriteLine("\nTop Schools.....");
-                foreach (var school in topSchools)
-                {
-                    Console.WriteLine($"{school.School} - {school.Conference} - {school.ProjectedPoints} - {school.NumberOfProspects}");
-                }
-
-                // Update the status and spinner
-                ctx.Status("Writing Top Schools CSV");
-
-                // Now, write these top schools to a CSV file in the schools directory for the year in question.
-                // The file should be named with the date, then top-schools.csv, such as 2021-10-03-top-schools.csv
-                // Also, write one line to a file that says how many schools there are, as well as the date, similar to 2022BoardInfo.csv
-                var schoolRankInfoFileName = $"ranks{Path.DirectorySeparatorChar}{scrapeYear}{Path.DirectorySeparatorChar}schools{Path.DirectorySeparatorChar}{today}-top-schools.csv";
-                var schoolInfoFileName = $"ranks{Path.DirectorySeparatorChar}{scrapeYear}{Path.DirectorySeparatorChar}{scrapeYear}SchoolInfo.csv";
-
-                //Write schools to csv with date.
-                using (var writer = new StreamWriter(schoolRankInfoFileName))
-                using (var csv = new CsvWriter(writer, CultureInfo.CurrentCulture))
-                {
-                    csv.WriteRecords(topSchools);
-                }
-
-                //Add School Info
-
-                // Create a School Info object from the parsed values.
-                //ScrapeDate,NumberOfSchools,TopSchool,TopProjectedPoints,ProspectCountForTopSchool
-                var schoolBoardInfo = new SchoolRankInfo(today, topSchools.Count, topSchools.First().School, topSchools.First().ProjectedPoints, topSchools.First().NumberOfProspects);
-                List<SchoolRankInfo> schoolInfos = new List<SchoolRankInfo>();
-                schoolInfos.Add(schoolBoardInfo);
-
-                var schoolConfig = new CsvConfiguration(CultureInfo.CurrentCulture);
-                schoolConfig.HasHeaderRecord =  false;
-                //Write projects to csv with date.
-                using (var stream = File.Open(schoolInfoFileName, FileMode.Append))
-                using (var writer = new StreamWriter(stream))
-                using (var csv = new CsvWriter(writer, schoolConfig))
-                {
-                    csv.WriteRecords(schoolInfos);
-                }
-
-                // Similar to the top schools, I want to sort the top states by points, then by number of prospects, then by number of schools.
-                var topStates = prospects.GroupBy(x => x.State)
-                    .Select(x => new {
-                        State = x.Key,
-                        ProjectedPoints = x.Sum(y => y.ProjectedPoints),
-                        NumberOfSchools = x.GroupBy(y => y.School).Count(), // Number of schools in the state.
-                        NumberOfProspects = x.Count()
-                    })
-                    .OrderByDescending(x => x.ProjectedPoints)
-                    .ThenByDescending(x => x.NumberOfProspects)
-                    .ToList();
-                // Chatty output to console.  It's messy but informative.
-                Console.WriteLine("\nTop States.....");
-                foreach (var state in topStates)
-                {
-                    Console.WriteLine($"{state.State} - {state.ProjectedPoints} - {state.NumberOfSchools} - {state.NumberOfProspects}");
-                }
-
-                states = topStates.Count();
-
-                // Now, write these top states to a CSV file in the states directory for the year in question.
-                // The file should be named with the date, then top-states.csv, such as 2021-10-03-top-states.csv
-                var stateRankInfoFileName = $"ranks{Path.DirectorySeparatorChar}{scrapeYear}{Path.DirectorySeparatorChar}states{Path.DirectorySeparatorChar}{today}-top-states.csv";
-                var stateInfoFileName = $"ranks{Path.DirectorySeparatorChar}{scrapeYear}{Path.DirectorySeparatorChar}{scrapeYear}StateInfo.csv";
-
-                //Write schools to csv with date.
-                using (var writer = new StreamWriter(stateRankInfoFileName))
-                using (var csv = new CsvWriter(writer, CultureInfo.CurrentCulture))
-                {
-                    csv.WriteRecords(topStates);
-                }
-                
                 ctx.Status("Done!");
             });
+        }
+
+        private static string GetUrlToScrape(string scrapeYear, Section pageSection)
+        {
+            return pageSection.Contains(scrapeYear + "Url") ?
+                pageSection[scrapeYear + "Url"].StringValue :
+                pageSection["UrlPattern"].StringValue.Replace("{year}", scrapeYear);
+        }
+
+        private static void ScrapeYear(StatusContext ctx, HtmlWeb webGet, string scrapeYear, string urlToScrape)
+        {
+            int schools = 0,
+                states = 0;
+
+            var document = webGet.Load(urlToScrape);
+            // This is still messy from debugging the different values.  It should be optimized.
+            var dn = document.DocumentNode;
+            // https://html-agility-pack.net/select-nodes
+            // 2022 NFL Draft was compiled using 1 Big Board(s), 14 1st RoundMock Draft(s), and 0 Team BasedMock Draft(s). 
+            // /html/body/div.container/div.consensus-mock-container/ul/li
+
+            var bigBoard = dn.SelectNodes("//div[contains(@class, 'consensus-mock-container')]/ul/li");
+            var draftInfo = dn.SelectNodes("//div[contains(@class, 'list-title')]");
+            var lastUpdated = draftInfo[0].ChildNodes[2].InnerText.Replace("Last Updated: ", "").Trim();
+            var boardCountContainer = draftInfo[0].ChildNodes[1];
+            //var bigboardsUsed = dn.SelectNodes("/html[1]/body[1]/div[1]/div[2]/div[2]/p[1]/span[1]");
+            //var mockDraftsUsed = dn.SelectNodes("/html[1]/body[1]/div[1]/div[2]/div[2]/p[1]/span[2]");
+            //var teamBasedMockDraftsUsed = dn.SelectNodes("/html[1]/body[1]/div[1]/div[2]/div[2]/p[1]/span[3]");
+            //bool bigBoardParsed = int.TryParse(bigboardsUsed[0].InnerText, out bigBoards);
+            //bool mockDraftParsed = int.TryParse(mockDraftsUsed[0].InnerText, out mockDrafts);
+            //bool teamMockDraftParsed = int.TryParse(teamBasedMockDraftsUsed[0].InnerText, out teamMockDrafts);
+            bool bigBoardParsed = int.TryParse(boardCountContainer.ChildNodes[1].InnerText, out int bigBoards);
+            bool mockDraftParsed = int.TryParse(boardCountContainer.ChildNodes[4].InnerText, out int mockDrafts);
+            bool teamMockDraftParsed = int.TryParse(boardCountContainer.ChildNodes[7].InnerText, out int teamMockDrafts);
+
+            Console.WriteLine("Big Board count: " + bigBoards);
+            Console.WriteLine("Mock Draft count: " + mockDrafts);
+            Console.WriteLine("Team Mock count: " + teamMockDrafts);
+
+            Console.WriteLine("Prospect count: " + bigBoard.Count);
+
+            // Get today's date in the format of yyyy-mm-dd
+            var today = DateTime.Now.ToString("yyyy-MM-dd");
+
+            // Create a ConsensusBigBoardInfo object from the parsed values.
+            var bigBoardInfo = new ConsensusBigBoardInfo(today, bigBoards, mockDrafts, teamMockDrafts, bigBoard.Count, lastUpdated);
+            var infos = new List<ConsensusBigBoardInfo>
+            {
+                bigBoardInfo
+            };
+
+            var baseDirectory = Path.Join("ranks", scrapeYear);
+            EnsureExists(baseDirectory);
+
+            // use CsvWriter to write bigBoardInfo to csv
+
+            //This is the file name we are going to write.
+            var bigBoardInfoFileName = Path.Combine(baseDirectory, $"{scrapeYear}BoardInfo.csv");
+
+            Console.WriteLine("Creating Draft Info csv...");
+
+            //Write projects to csv with date.
+            WriteToCsvFile(bigBoardInfoFileName, infos);
+
+            ctx.SpinnerStyle(Style.Parse("green"));
+
+            AnsiConsole.MarkupLine("Doing some prospect work...");
+            var prospects = FindProspects(bigBoard, today);
+
+
+            // Update the status and spinner
+            ctx.Status("Writing draft prospect CSV");
+            
+            var playerInfoDirectory = Path.Combine(baseDirectory, "players");
+            EnsureExists(playerInfoDirectory);
+
+            var playerInfoFileName = Path.Combine(playerInfoDirectory, $"{today}-ranks.csv");
+            var collectedRanksFileName = Path.Combine(baseDirectory, $"{scrapeYear}ranks.csv");
+
+            //Write projects to csv with date.
+            using (var writer = new StreamWriter(playerInfoFileName))
+            using (var csv = new CsvWriter(writer, CultureInfo.CurrentCulture))
+            {
+                csv.WriteRecords(prospects);
+            }
+
+            ctx.Status("Writing to collected ranks CSV");
+            //Write projects to csv with date.
+            WriteToCsvFile(collectedRanksFileName, prospects);
+
+            // OK, I'm going to use LINQ to sort the top schools by points, then by number of prospects.
+            // The output I want here is: Rank, School, Conference, Points, Number of Prospects
+            ctx.Status($"Putting together top schools....");
+
+            var topSchools = prospects.GroupBy(x => x.School)
+                .Select(x => new
+                {
+                    School = x.Key,
+                    Conference = x.First().Conference,
+                    ProjectedPoints = x.Sum(y => y.ProjectedPoints),
+                    NumberOfProspects = x.Count()
+                })
+                .OrderByDescending(x => x.ProjectedPoints)
+                .ThenByDescending(x => x.NumberOfProspects)
+                .ToList();
+            schools = topSchools.Count;
+
+            // Chatty output to console.  It's messy but informative.
+            Console.WriteLine("\nTop Schools.....");
+            foreach (var school in topSchools)
+            {
+                Console.WriteLine($"{school.School} - {school.Conference} - {school.ProjectedPoints} - {school.NumberOfProspects}");
+            }
+
+            // Update the status and spinner
+            ctx.Status("Writing Top Schools CSV");
+
+            // Now, write these top schools to a CSV file in the schools directory for the year in question.
+            // The file should be named with the date, then top-schools.csv, such as 2021-10-03-top-schools.csv
+            // Also, write one line to a file that says how many schools there are, as well as the date, similar to 2022BoardInfo.csv
+            var schoolInfoDirectory = Path.Combine(baseDirectory, "schools");
+            EnsureExists(schoolInfoDirectory);
+
+            var schoolRankInfoFileName = Path.Combine(schoolInfoDirectory, $"{today}-top-schools.csv");
+            var schoolInfoFileName = Path.Combine(baseDirectory, $"{scrapeYear}SchoolInfo.csv");
+
+            //Write schools to csv with date.
+            using (var writer = new StreamWriter(schoolRankInfoFileName))
+            using (var csv = new CsvWriter(writer, CultureInfo.CurrentCulture))
+            {
+                csv.WriteRecords(topSchools);
+            }
+
+            //Add School Info
+
+            // Create a School Info object from the parsed values.
+            //ScrapeDate,NumberOfSchools,TopSchool,TopProjectedPoints,ProspectCountForTopSchool
+            var topSchool = topSchools.First();
+            var schoolBoardInfo = new SchoolRankInfo(today, topSchools.Count, topSchool.School, topSchool.ProjectedPoints, topSchool.NumberOfProspects);
+            var schoolInfos = new List<SchoolRankInfo>
+            {
+                schoolBoardInfo
+            };
+
+            //Write projects to csv with date.
+            WriteToCsvFile(schoolInfoFileName, schoolInfos);
+
+            // Similar to the top schools, I want to sort the top states by points, then by number of prospects, then by number of schools.
+            var topStates = prospects.GroupBy(x => x.State)
+                .Select(x => new
+                {
+                    State = x.Key,
+                    ProjectedPoints = x.Sum(y => y.ProjectedPoints),
+                    NumberOfSchools = x.GroupBy(y => y.School).Count(), // Number of schools in the state.
+                        NumberOfProspects = x.Count()
+                })
+                .OrderByDescending(x => x.ProjectedPoints)
+                .ThenByDescending(x => x.NumberOfProspects)
+                .ToList();
+            // Chatty output to console.  It's messy but informative.
+            Console.WriteLine("\nTop States.....");
+            foreach (var state in topStates)
+            {
+                Console.WriteLine($"{state.State} - {state.ProjectedPoints} - {state.NumberOfSchools} - {state.NumberOfProspects}");
+            }
+
+            states = topStates.Count;
+
+            // Now, write these top states to a CSV file in the states directory for the year in question.
+            // The file should be named with the date, then top-states.csv, such as 2021-10-03-top-states.csv
+            var statesDirectory = Path.Combine(baseDirectory, "states");
+            EnsureExists(statesDirectory);
+
+            var stateRankInfoFileName = Path.Combine(statesDirectory, $"{today}-top-states.csv");
+            var stateInfoFileName = Path.Combine(baseDirectory, $"{scrapeYear}StateInfo.csv");
+
+            //Write schools to csv with date.
+            using (var writer = new StreamWriter(stateRankInfoFileName))
+            using (var csv = new CsvWriter(writer, CultureInfo.CurrentCulture))
+            {
+                csv.WriteRecords(topStates);
+            }
 
             // Give a rendered result to the terminal.
             AnsiConsole.Render(new BarChart()
@@ -222,21 +234,40 @@ namespace prospect_scraper_mddb_2022
             .AddItem("Schools", schools, Color.Blue)
             .AddItem("States", states, Color.Aqua)
             );
-
         }
 
-        public static List<ProspectRanking> findProspects(HtmlNodeCollection nodes, string todayString)
+        private static void WriteToCsvFile<T>(string fileName, IList<T> data)
         {
-            List<ProspectRanking> prospectRankings = new List<ProspectRanking>();
+            var csvConfig = new CsvConfiguration(CultureInfo.CurrentCulture)
+            {
+                HasHeaderRecord = false
+            };
+            using (var stream = File.Open(fileName, FileMode.Append))
+            using (var writer = new StreamWriter(stream))
+            using (var csv = new CsvWriter(writer, csvConfig))
+            {
+                csv.WriteRecords(data);
+            }
+        }
+
+        private static void EnsureExists(string directory)
+        {
+            if(!Directory.Exists(directory))
+                Directory.CreateDirectory(directory);
+        }
+
+        private static List<ProspectRanking> FindProspects(HtmlNodeCollection nodes, string todayString)
+        {
+            var prospectRankings = new List<ProspectRanking>();
 
             //read in CSV from info/RanksToProjectedPoints.csv
             var dt = new DataTable();
-            using (var reader = new StreamReader($"info{Path.DirectorySeparatorChar}RanksToProjectedPoints.csv"))
+            using (var reader = new StreamReader(Path.Combine("info", "RanksToProjectedPoints.csv")))
             using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
             {
                 // Do any configuration to `CsvReader` before creating CsvDataReader.
                 using (var dr = new CsvDataReader(csv))
-                {		
+                {
                     dt.Load(dr);
                 }
             }
@@ -244,28 +275,22 @@ namespace prospect_scraper_mddb_2022
             var ranksToPoints = dt.AsEnumerable()
                     .ToDictionary<DataRow, string, string>(row => row.Field<string>(0),
                                                         row => row.Field<string>(1));
-
-
-
-            
+                        
             var dt2 = new DataTable();
-            using (var reader = new StreamReader($"info{Path.DirectorySeparatorChar}SchoolStatesAndConferences.csv"))
+            using (var reader = new StreamReader(Path.Combine("info", "SchoolStatesAndConferences.csv")))
             using (var csv = new CsvReader(reader, CultureInfo.InvariantCulture))
             {
                 // Do any configuration to `CsvReader` before creating CsvDataReader.
                 using (var dr = new CsvDataReader(csv))
-                {		
+                {
                     dt2.Load(dr);
                 }
             }
 
             var schoolsToStatesAndConfs = dt2.AsEnumerable()
-                    .ToDictionary<DataRow, string, (string, string)>(row => row.Field<string>(0),
-                                                        row => (row.Field<string>(1), row.Field<string>(2))
-                                                        );
-
-
-
+                    .ToDictionary(row => row.Field<string>(0),
+                                  row => (row.Field<string>(1), row.Field<string>(2))
+                                 );
 
             foreach(var node in nodes)
             {
@@ -275,8 +300,6 @@ namespace prospect_scraper_mddb_2022
                 string projectedDraftSpot = "";
                 string projectedDraftTeam = "";
                 string playerSchool = "";
-
-
 
                 var actualPickStuff = pickContainer.FirstChild;
                 string currentRank = actualPickStuff.FirstChild.InnerText;
@@ -318,14 +341,12 @@ namespace prospect_scraper_mddb_2022
                             
                 //var ranking = new ProspectRanking();
                 
-                playerSchool = convertSchool(playerSchool);
-                string schoolState = "";
-                string schoolConference = "";
-                string leagifyPoints = "";
-                
-                leagifyPoints = ranksToPoints[currentRank];
-                schoolConference  = schoolsToStatesAndConfs[playerSchool].Item1;
-                schoolState = schoolsToStatesAndConfs[playerSchool].Item2;
+                playerSchool = ConvertSchool(playerSchool);
+                var leagifyPoints = ranksToPoints.GetValueOrDefault(currentRank, "1");
+
+                var playerSchoolInfo = schoolsToStatesAndConfs.GetValueOrDefault(playerSchool, ("", ""));
+                var schoolConference  = playerSchoolInfo.Item1;
+                var schoolState = playerSchoolInfo.Item2;
 
                 Console.WriteLine($"Player: {playerName} at rank {currentRank} from {playerSchool} playing {playerPosition} got up to peak rank {peakRank} with {leagifyPoints} possible points");
                 
@@ -333,12 +354,10 @@ namespace prospect_scraper_mddb_2022
                 prospectRankings.Add(currentplayer);
             }
 
-
-
             return prospectRankings;
         }
 
-        public static string convertSchool(string schoolName)
+        private static string ConvertSchool(string schoolName)
         {
             schoolName = schoolName switch
             {
@@ -347,9 +366,6 @@ namespace prospect_scraper_mddb_2022
                 _ => schoolName,
             };
             return schoolName;
-        }
-
-    
-        
+        }    
     }
 }

--- a/prospect-scraper-mddb-2022.csproj
+++ b/prospect-scraper-mddb-2022.csproj
@@ -13,4 +13,22 @@
     <PackageReference Include="Spectre.Console" Version="0.39.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="info\PositionInfo.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="info\RanksToProjectedPoints.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="info\SchoolStatesAndConferences.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="info\StatesToRegions.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="scraper.conf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/scraper.conf
+++ b/scraper.conf
@@ -4,11 +4,12 @@ SomeString = Hello World!
 SomeInteger = 10 # an inline comment
 SomeFloat = 20.05
 SomeBoolean = true
-SomeArray = { 1, 2, 3 } # Potentially use this when I start doing multiple years
+YearsToScrape = { 2022 } # Potentially use this when I start doing multiple years
 YearToScrape = 2022
 
 
 [Pages]
+UrlPattern = "https://www.nflmockdraftdatabase.com/big-boards/{year}/consensus-big-board-{year}"
 2022Url = "https://www.nflmockdraftdatabase.com/big-boards/2022/consensus-big-board-2022"
 2023Url = "https://www.nflmockdraftdatabase.com/big-boards/2023/consensus-big-board-2023"
 2024Url = "https://www.nflmockdraftdatabase.com/big-boards/2024/consensus-big-board-2024"


### PR DESCRIPTION
Refactored the code to:
1. Use multiple years from `scraper.conf`
2. Use a generic pattern for getting URL to scrape for any given year with the option to override.
3. Broke the single function into multiple parts for ease of understanding and maintenance.

Resolves #10 